### PR TITLE
fix: cache busting with script hash rename

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -10,11 +10,29 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: aws-actions/configure-aws-credentials@v3
+      - name: Checkout code
+        uses: actions/checkout@v1
+
+      - name: Set up AWS credentials
+        uses: aws-actions/configure-aws-credentials@v3
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ap-southeast-2
-      - name: Sync to s3
-        run: aws s3 sync ./frontEnd s3://mtblackheathwind-test
+
+      - name: Generate file hash and rename
+        run: |
+          # Find all .js files and generate a hash
+          for file in ./frontEnd/*.js; do
+            FILE_HASH=$(sha256sum "$file" | cut -d ' ' -f 1)
+            NEW_NAME="$(basename "$file" .js).${FILE_HASH}.js"
+            mv "$file" "./frontEnd/$NEW_NAME"
+            
+            # Update references in HTML files
+            for html in ./frontEnd/*.html; do
+              sed -i "s/$(basename "$file")/$NEW_NAME/g" "$html"
+            done
+          done
+
+      - name: Sync to S3
+        run: aws s3 sync ./frontEnd s3://mtblackheathwind-test --delete


### PR DESCRIPTION
Changes in script.js are not being seen after deployment because of cacheing of the file. This change aims to fix that by generating a hash of the file and appending it to its filename, and also changing the reference to the script file in index.html